### PR TITLE
Fix "MultiModel minecraft:builtin/missing is empty"

### DIFF
--- a/src/main/resources/assets/betterwithmods/blockstates/invisible_light.json
+++ b/src/main/resources/assets/betterwithmods/blockstates/invisible_light.json
@@ -1,27 +1,12 @@
 {
-  "forge_marker": 1,
-  "defaults": {
-  },
-  "variants": {
-    "normal": [
-      {}
-    ],
-    "inventory": [
-      {
-        "transform": "forge:default-block"
+  "multipart": [
+    {
+      "when": {
+        "sunlight": "true"
+      },
+      "apply": {
+        "model": "builtin/generated"
       }
-    ],
-    "facing": {
-      "north": {},
-      "south": {},
-      "east": {},
-      "west": {},
-      "up": {},
-      "down": {}
-    },
-    "sunlight": {
-      "true": {},
-      "false": {}
     }
-  }
+  ]
 }

--- a/src/main/resources/assets/betterwithmods/blockstates/temporary_water.json
+++ b/src/main/resources/assets/betterwithmods/blockstates/temporary_water.json
@@ -2,7 +2,7 @@
   "multipart": [
     {
       "when": {
-        "level": "0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15"
+        "level": "0"
       },
       "apply": {
         "model": "builtin/generated"


### PR DESCRIPTION
Very small PR. This should fix the last BWM-related errors we have.
When running BWM alone, I don't have any warning in the log anymore.
The problem was a wrong dummy model for betterwithmods:invisible_light.