### PR TITLE
[Complete] Hardcore Structures

### DIFF
--- a/src/main/java/betterwithmods/BWCrafting.java
+++ b/src/main/java/betterwithmods/BWCrafting.java
@@ -261,6 +261,10 @@ public class BWCrafting {
         GameRegistry.addRecipe(new ItemStack(Items.CHAINMAIL_LEGGINGS), "CCC", "C C", "C C", 'C', ItemMaterial.getMaterial("chain_mail"));
         GameRegistry.addRecipe(new ItemStack(Items.CHAINMAIL_BOOTS), "C C", "C C", 'C', ItemMaterial.getMaterial("chain_mail"));
         GameRegistry.addShapedRecipe(new ItemStack(BWMBlocks.STEEL_ANVIL), "SSS", " S ", "SSS", 'S', ItemMaterial.getMaterial("ingot_steel"));
+        if(BWConfig.hardcoreStructures) {
+            RecipeUtils.removeRecipes(Blocks.ENCHANTING_TABLE);
+            RecipeUtils.removeRecipes(Items.BREWING_STAND, 0);
+        }
     }
 
     private static void addSawRecipes() {

--- a/src/main/java/betterwithmods/BWMod.java
+++ b/src/main/java/betterwithmods/BWMod.java
@@ -132,11 +132,13 @@ public class BWMod {
     }
 
     private static void registerWorldGen() {
-        MapGenStructureIO.registerStructure(BWMapGenScatteredFeature.Start.class, "BWTemple");
-        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.DesertPyramid.class, "BWTeDP");
-        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.JunglePyramid.class, "BWTeJP");
-        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.SwampHut.class, "BWTeSH");
-        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.Igloo.class, "BWIglu");
+        if(BWConfig.hardcoreStructures) {
+            MapGenStructureIO.registerStructure(BWMapGenScatteredFeature.Start.class, "BWTemple");
+            MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.DesertPyramid.class, "BWTeDP");
+            MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.JunglePyramid.class, "BWTeJP");
+            MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.SwampHut.class, "BWTeSH");
+            MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.Igloo.class, "BWIglu");
+        }
     }
 
     @EventHandler

--- a/src/main/java/betterwithmods/BWMod.java
+++ b/src/main/java/betterwithmods/BWMod.java
@@ -16,9 +16,12 @@ import betterwithmods.util.HardcoreFunctions;
 import betterwithmods.util.InvUtils;
 import betterwithmods.util.RecipeUtils;
 import betterwithmods.util.item.ItemExt;
+import betterwithmods.world.BWComponentScatteredFeaturePieces;
+import betterwithmods.world.BWMapGenScatteredFeature;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
+import net.minecraft.world.gen.structure.MapGenStructureIO;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fml.common.Loader;
@@ -114,6 +117,7 @@ public class BWMod {
         MinecraftForge.EVENT_BUS.register(new BlastingOilEvent());
         MinecraftForge.EVENT_BUS.register(new BreedingHardnessEvent());
         MinecraftForge.EVENT_BUS.register(new HardcoreEndermenEvent());
+        MinecraftForge.TERRAIN_GEN_BUS.register(new BWMWorldGenEvent());
     }
 
     private static void registerEntities() {
@@ -124,6 +128,14 @@ public class BWMod {
         BWRegistry.registerEntity(EntityShearedCreeper.class, "entityShearedCreeper", 64, 1, true);
         BWRegistry.registerEntity(EntityBroadheadArrow.class, "entityBroadheadArrow", 64, 1, true);
         BWRegistry.registerEntity(EntityFallingGourd.class, "entityFallingGourd", 64, 1, true);
+    }
+
+    private static void registerWorldGen() {
+        MapGenStructureIO.registerStructure(BWMapGenScatteredFeature.Start.class, "BWTemple");
+        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.DesertPyramid.class, "BWTeDP");
+        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.JunglePyramid.class, "BWTeJP");
+        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.SwampHut.class, "BWTeSH");
+        MapGenStructureIO.registerStructureComponent(BWComponentScatteredFeaturePieces.Igloo.class, "BWIglu");
     }
 
     @EventHandler
@@ -152,6 +164,7 @@ public class BWMod {
         getLoadedModules().forEach(ICompatModule::preInit);
         BWCrafting.init();
         registerEntities();
+        registerWorldGen();
         CapabilityManager.INSTANCE.register(IMechanicalPower.class, new MechanicalCapability.CapabilityMechanicalPower(), MechanicalCapability.DefaultMechanicalPower.class);
         BWNetwork.INSTANCE.init();
         proxy.preInit();

--- a/src/main/java/betterwithmods/BWMod.java
+++ b/src/main/java/betterwithmods/BWMod.java
@@ -164,7 +164,6 @@ public class BWMod {
         getLoadedModules().forEach(ICompatModule::preInit);
         BWCrafting.init();
         registerEntities();
-        registerWorldGen();
         CapabilityManager.INSTANCE.register(IMechanicalPower.class, new MechanicalCapability.CapabilityMechanicalPower(), MechanicalCapability.DefaultMechanicalPower.class);
         BWNetwork.INSTANCE.init();
         proxy.preInit();
@@ -172,6 +171,7 @@ public class BWMod {
 
     @EventHandler
     public void init(FMLInitializationEvent evt) {
+        registerWorldGen();
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, new BWGuiHandler());
         BWRegistry.registerHeatSources();
         GameRegistry.registerFuelHandler(new BWFuelHandler());

--- a/src/main/java/betterwithmods/config/BWConfig.java
+++ b/src/main/java/betterwithmods/config/BWConfig.java
@@ -59,6 +59,7 @@ public class BWConfig {
     public static boolean hardcoreLavaBuckets;
     public static boolean hardcoreEndermen;
     public static boolean hardcoreRedstone;
+    public static boolean hardcoreStructures;
 
     public static void init(File file) {
         config = new Configuration(file);
@@ -120,6 +121,7 @@ public class BWConfig {
         hardcoreLavaBuckets = hardcoreBuckets && config.getBoolean("Hardcore Lava Buckets",HARDCORE,true,"Makes lava buckets hot if you don't have a fire resistance potion");
         hardcoreEndermen = config.getBoolean("Hardcore Endermen", HARDCORE,true,"Changes to Endermen AI that make them even more menacing");
         hardcoreRedstone = config.get(HARDCORE, "Hardcore Redstone",true,"Prevents wooden doors, trapdoors, and fence gates from being activated by redstone. Changes various redstone related recipes").setRequiresMcRestart(true).getBoolean();
+        hardcoreStructures = config.get(HARDCORE, "Hardcore Structures",true,"Changes various structures to be affected by the Hardcore Spawn radius. Removes Enchanting Table and Brewing Stand recipes").setRequiresMcRestart(true).getBoolean();
         config.save();
     }
 

--- a/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
+++ b/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
@@ -17,8 +17,14 @@ public class BWMWorldGenEvent {
             event.setNewGen(new BWMapGenScatteredFeature());
     }
 
+
+
     public static boolean isInRadius(World world, BlockPos pos) {
+        return isInRadius(world, pos.getX(), pos.getZ());
+    }
+
+    public static boolean isInRadius(World world, int x, int z) {
         BlockPos center = world.getSpawnPoint();
-        return Math.sqrt(Math.pow(pos.getX() - center.getX(), 2) + Math.pow(pos.getZ() - center.getZ(), 2)) < RespawnEventHandler.HARDCORE_SPAWN_RADIUS;
+        return Math.sqrt(Math.pow(x - center.getX(), 2) + Math.pow(z - center.getZ(), 2)) < RespawnEventHandler.HARDCORE_SPAWN_RADIUS;
     }
 }

--- a/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
+++ b/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
@@ -1,5 +1,6 @@
 package betterwithmods.event;
 
+import betterwithmods.config.BWConfig;
 import betterwithmods.world.BWMapGenScatteredFeature;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -13,6 +14,9 @@ public class BWMWorldGenEvent {
 
     @SubscribeEvent
     public void overrideScatteredFeature(InitMapGenEvent event){
+        if(!BWConfig.hardcoreStructures)
+            return;
+
         if(event.getType().equals(InitMapGenEvent.EventType.SCATTERED_FEATURE))
             event.setNewGen(new BWMapGenScatteredFeature());
     }

--- a/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
+++ b/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
@@ -1,0 +1,17 @@
+package betterwithmods.event;
+
+import betterwithmods.world.BWMapGenScatteredFeature;
+import net.minecraftforge.event.terraingen.InitMapGenEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Created by blueyu2 on 11/27/16.
+ */
+public class BWMWorldGenEvent {
+
+    @SubscribeEvent
+    public void overrideScatteredFeature(InitMapGenEvent event){
+        if(event.getType().equals(InitMapGenEvent.EventType.SCATTERED_FEATURE))
+            event.setNewGen(new BWMapGenScatteredFeature());
+    }
+}

--- a/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
+++ b/src/main/java/betterwithmods/event/BWMWorldGenEvent.java
@@ -1,6 +1,8 @@
 package betterwithmods.event;
 
 import betterwithmods.world.BWMapGenScatteredFeature;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.event.terraingen.InitMapGenEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
@@ -13,5 +15,10 @@ public class BWMWorldGenEvent {
     public void overrideScatteredFeature(InitMapGenEvent event){
         if(event.getType().equals(InitMapGenEvent.EventType.SCATTERED_FEATURE))
             event.setNewGen(new BWMapGenScatteredFeature());
+    }
+
+    public static boolean isInRadius(World world, BlockPos pos) {
+        BlockPos center = world.getSpawnPoint();
+        return Math.sqrt(Math.pow(pos.getX() - center.getX(), 2) + Math.pow(pos.getZ() - center.getZ(), 2)) < RespawnEventHandler.HARDCORE_SPAWN_RADIUS;
     }
 }

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -22,17 +22,15 @@ import java.util.Random;
  * Created by blueyu2 on 11/27/16.
  */
 public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeaturePieces {
-
-    private static boolean isInRadius(World worldIn, StructureBoundingBox structureBoundingBoxIn) {
-        return BWMWorldGenEvent.isInRadius(worldIn, structureBoundingBoxIn.maxX - structureBoundingBoxIn.minX, structureBoundingBoxIn.maxZ - structureBoundingBoxIn.minZ);
-    }
-
     public static class DesertPyramid extends ComponentScatteredFeaturePieces.DesertPyramid
     {
+        final int worldX, worldZ;
 
-        DesertPyramid(Random p_i2062_1_, int p_i2062_2_, int p_i2062_3_)
+        DesertPyramid(Random random, int x, int z)
         {
-            super(p_i2062_1_, p_i2062_2_, p_i2062_3_);
+            super(random, x, z);
+            this.worldX = x;
+            this.worldZ = z;
         }
 
         @Override
@@ -82,7 +80,7 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 5, 0, structureBoundingBoxIn);
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 5, 0, structureBoundingBoxIn);
 
-            if(isInRadius(worldIn, structureBoundingBoxIn)) {
+            if(BWMWorldGenEvent.isInRadius(worldIn, worldX, worldZ)) {
                 //Dig hole
                 this.setAir(worldIn, 10, 0, 10, structureBoundingBoxIn);
                 this.setAir(worldIn, 11, 0, 10, structureBoundingBoxIn);
@@ -222,9 +220,13 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
 
     public static class JunglePyramid extends ComponentScatteredFeaturePieces.JunglePyramid
     {
+        final int worldX, worldZ;
+
         JunglePyramid(Random rand, int x, int z)
         {
             super(rand, x, z);
+            this.worldX = x;
+            this.worldZ = z;
         }
 
         @Override
@@ -240,7 +242,7 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
             this.setAir(worldIn, 6, 3, 10, structureBoundingBoxIn);
             this.setAir(worldIn, 5, 3, 10, structureBoundingBoxIn);
 
-            if(isInRadius(worldIn, structureBoundingBoxIn)) {
+            if(BWMWorldGenEvent.isInRadius(worldIn, worldX, worldZ)) {
                 //Remove hooks
                 this.setAir(worldIn, 1, -3, 8, structureBoundingBoxIn);
                 this.setAir(worldIn, 4, -3, 8, structureBoundingBoxIn);

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -3,10 +3,7 @@ package betterwithmods.world;
 import betterwithmods.BWMBlocks;
 import betterwithmods.blocks.BlockAesthetic;
 import betterwithmods.event.BWMWorldGenEvent;
-import net.minecraft.block.BlockFlowerPot;
-import net.minecraft.block.BlockLadder;
-import net.minecraft.block.BlockPlanks;
-import net.minecraft.block.BlockStairs;
+import net.minecraft.block.*;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.monster.EntityWitch;
 import net.minecraft.init.Blocks;
@@ -25,6 +22,10 @@ import java.util.Random;
  * Created by blueyu2 on 11/27/16.
  */
 public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeaturePieces {
+
+    private static boolean isInRadius(World worldIn, StructureBoundingBox structureBoundingBoxIn) {
+        return BWMWorldGenEvent.isInRadius(worldIn, structureBoundingBoxIn.maxX - structureBoundingBoxIn.minX, structureBoundingBoxIn.maxZ - structureBoundingBoxIn.minZ);
+    }
 
     public static class DesertPyramid extends ComponentScatteredFeaturePieces.DesertPyramid
     {
@@ -81,7 +82,7 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 5, 0, structureBoundingBoxIn);
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 5, 0, structureBoundingBoxIn);
 
-            if(BWMWorldGenEvent.isInRadius(worldIn, new BlockPos(this.getXWithOffset(10, 10), this.getYWithOffset(1), this.getZWithOffset(10, 10)))) {
+            if(isInRadius(worldIn, structureBoundingBoxIn)) {
                 //Dig hole
                 this.setAir(worldIn, 10, 0, 10, structureBoundingBoxIn);
                 this.setAir(worldIn, 11, 0, 10, structureBoundingBoxIn);
@@ -236,17 +237,58 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
 
             this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 5, 4, 11, structureBoundingBoxIn);
             this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 6, 4, 11, structureBoundingBoxIn);
-            //TODO add Vessel of the Dragon
             this.setAir(worldIn, 6, 3, 10, structureBoundingBoxIn);
-            this.setBlockState(worldIn, BWMBlocks.HAND_CRANK.getDefaultState(), 5, 3, 10, structureBoundingBoxIn);
+            this.setAir(worldIn, 5, 3, 10, structureBoundingBoxIn);
 
-            //TODO remove tripwire, remove chest loot, center lever & wall. change dispensers to have either rotten or poison arrows?
+            if(isInRadius(worldIn, structureBoundingBoxIn)) {
+                //Remove hooks
+                this.setAir(worldIn, 1, -3, 8, structureBoundingBoxIn);
+                this.setAir(worldIn, 4, -3, 8, structureBoundingBoxIn);
+                //Remove tripwire
+                this.setAir(worldIn, 2, -3, 8, structureBoundingBoxIn);
+                this.setAir(worldIn, 3, -3, 8, structureBoundingBoxIn);
+                //Re-add hooks
+                this.setBlockState(worldIn, Blocks.TRIPWIRE_HOOK.getDefaultState().withProperty(BlockTripWireHook.FACING, EnumFacing.EAST), 1, -3, 8, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.TRIPWIRE_HOOK.getDefaultState().withProperty(BlockTripWireHook.FACING, EnumFacing.WEST), 4, -3, 8, structureBoundingBoxIn);
+
+                //Remove hooks
+                this.setAir(worldIn, 7, -3, 1, structureBoundingBoxIn);
+                this.setAir(worldIn, 7, -3, 5, structureBoundingBoxIn);
+                //Remove tripwire
+                this.setAir(worldIn, 7, -3, 2, structureBoundingBoxIn);
+                this.setAir(worldIn, 7, -3, 3, structureBoundingBoxIn);
+                this.setAir(worldIn, 7, -3, 4, structureBoundingBoxIn);
+                //Re-add hooks
+                this.setBlockState(worldIn, Blocks.TRIPWIRE_HOOK.getDefaultState().withProperty(BlockTripWireHook.FACING, EnumFacing.NORTH), 7, -3, 1, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.TRIPWIRE_HOOK.getDefaultState().withProperty(BlockTripWireHook.FACING, EnumFacing.SOUTH), 7, -3, 5, structureBoundingBoxIn);
+
+                //Remove puzzle
+                this.setAir(worldIn, 9, -2, 12, structureBoundingBoxIn);
+                this.setAir(worldIn, 9, -2, 11, structureBoundingBoxIn);
+                this.setAir(worldIn, 9, -3, 11, structureBoundingBoxIn);
+
+                //Remove Chest Loot
+                removeChest(worldIn, 8, -3, 3, randomIn);
+                removeChest(worldIn, 9, -3, 10, randomIn);
+            }
+            else {
+                this.setBlockState(worldIn, BWMBlocks.HAND_CRANK.getDefaultState(), 5, 3, 10, structureBoundingBoxIn);
+                //TODO add Vessel of the Dragon @ 6, 3, 10
+            }
+            //TODO change dispensers to have either rotten or poison arrows?
 
             return result;
         }
 
         private void setAir(World world, int x, int y, int z, StructureBoundingBox structureBoundingBox) {
             this.setBlockState(world, Blocks.AIR.getDefaultState(), x, y, z, structureBoundingBox);
+        }
+
+        private void removeChest(World worldIn, int x, int y, int z, Random randomIn) {
+            TileEntity tileentity = worldIn.getTileEntity(new BlockPos(this.getXWithOffset(x, z), this.getYWithOffset(y), this.getZWithOffset(x, z)));
+            if (tileentity instanceof TileEntityChest)
+                //TODO create jungle temple loot table?
+                ((TileEntityChest)tileentity).setLootTable(null, randomIn.nextLong());
         }
     }
 }

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -1,6 +1,12 @@
 package betterwithmods.world;
 
+import betterwithmods.event.BWMWorldGenEvent;
+import net.minecraft.block.BlockLadder;
 import net.minecraft.init.Blocks;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.ComponentScatteredFeaturePieces;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
@@ -23,8 +29,6 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
         @Override
         public boolean addComponentParts(World worldIn, Random randomIn, StructureBoundingBox structureBoundingBoxIn) {
             boolean result = super.addComponentParts(worldIn, randomIn, structureBoundingBoxIn);
-            //TODO only when past spawn radius
-            this.setBlockState(worldIn, Blocks.ENCHANTING_TABLE.getDefaultState(), 10, 1, 10, structureBoundingBoxIn);
 
             //Replace clay with obsidian
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 7, structureBoundingBoxIn);
@@ -69,7 +73,42 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 5, 0, structureBoundingBoxIn);
             this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 5, 0, structureBoundingBoxIn);
 
+            if(BWMWorldGenEvent.isInRadius(worldIn, new BlockPos(this.getXWithOffset(10, 10), this.getYWithOffset(1), this.getZWithOffset(10, 10)))) {
+                //Dig hole
+                this.setAir(worldIn, 10, 0, 10, structureBoundingBoxIn);
+                this.setAir(worldIn, 11, 0, 10, structureBoundingBoxIn);
+                this.setAir(worldIn, 10, 0, 9, structureBoundingBoxIn);
+                this.setAir(worldIn, 10, -11, 10, structureBoundingBoxIn);
+                for(int x = 0; x < 3; x++) {
+                    for(int z = 0; z < 3; z++) {
+                        this.setAir(worldIn, 9 + x, -12, 9 + z, structureBoundingBoxIn);
+                        this.setAir(worldIn, 9 + x, -13, 9 + z, structureBoundingBoxIn);
+                    }
+                }
+
+                //Create ladder
+                for(int i = 0; i >= -13; i--)
+                    this.setBlockState(worldIn, Blocks.LADDER.getDefaultState().withProperty(BlockLadder.FACING, EnumFacing.WEST), 11, i, 9, structureBoundingBoxIn);
+
+                //Remove chest loot
+                for (EnumFacing enumfacing : EnumFacing.Plane.HORIZONTAL)
+                {
+                    int k1 = enumfacing.getFrontOffsetX() * 2;
+                    int l1 = enumfacing.getFrontOffsetZ() * 2;
+                    TileEntity tileentity = worldIn.getTileEntity(new BlockPos(this.getXWithOffset(10 + k1, 10 + l1), this.getYWithOffset(-11), this.getZWithOffset(10 + k1, 10 + l1)));
+                    if (tileentity instanceof TileEntityChest)
+                        //TODO create desert temple loot table that only has rotten flesh and bones?
+                        ((TileEntityChest)tileentity).setLootTable(null, randomIn.nextLong());
+                }
+            }
+            else
+                this.setBlockState(worldIn, Blocks.ENCHANTING_TABLE.getDefaultState(), 10, 1, 10, structureBoundingBoxIn);
+
             return result;
+        }
+
+        private void setAir(World world, int x, int y, int z, StructureBoundingBox structureBoundingBox) {
+            this.setBlockState(world, Blocks.AIR.getDefaultState(), x, y, z, structureBoundingBox);
         }
     }
 }

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -1,0 +1,75 @@
+package betterwithmods.world;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.structure.ComponentScatteredFeaturePieces;
+import net.minecraft.world.gen.structure.StructureBoundingBox;
+
+import java.util.Random;
+
+/**
+ * Created by blueyu2 on 11/27/16.
+ */
+public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeaturePieces {
+
+    public static class DesertPyramid extends ComponentScatteredFeaturePieces.DesertPyramid
+    {
+
+        DesertPyramid(Random p_i2062_1_, int p_i2062_2_, int p_i2062_3_)
+        {
+            super(p_i2062_1_, p_i2062_2_, p_i2062_3_);
+        }
+
+        @Override
+        public boolean addComponentParts(World worldIn, Random randomIn, StructureBoundingBox structureBoundingBoxIn) {
+            boolean result = super.addComponentParts(worldIn, randomIn, structureBoundingBoxIn);
+            //TODO only when past spawn radius
+            this.setBlockState(worldIn, Blocks.ENCHANTING_TABLE.getDefaultState(), 10, 1, 10, structureBoundingBoxIn);
+
+            //Replace clay with obsidian
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 7, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 8, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 0, 9, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 0, 9, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 8, 0, 10, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 12, 0, 10, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 7, 0, 10, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 13, 0, 10, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 0, 11, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 0, 11, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 12, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 13, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 10, 0, 10, structureBoundingBoxIn);
+            for (int j2 = 0; j2 <= this.scatteredFeatureSizeX - 1; j2 += this.scatteredFeatureSizeX - 1)
+            {
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 2, 2, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 3, 2, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 4, 1, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 4, 3, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 5, 2, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 6, 1, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 6, 3, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 7, 1, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 7, 2, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), j2, 7, 3, structureBoundingBoxIn);
+            }
+            for (int k2 = 2; k2 <= this.scatteredFeatureSizeX - 3; k2 += this.scatteredFeatureSizeX - 3 - 2)
+            {
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2, 2, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2, 3, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 - 1, 4, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 + 1, 4, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2, 5, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 - 1, 6, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 + 1, 6, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 - 1, 7, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2, 7, 0, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), k2 + 1, 7, 0, structureBoundingBoxIn);
+            }
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 9, 5, 0, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.OBSIDIAN.getDefaultState(), 11, 5, 0, structureBoundingBoxIn);
+
+            return result;
+        }
+    }
+}

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -189,25 +189,23 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
                     }
                 }
 
-                //TODO have witches spawn randomly around hut instead of same spot. or at least have two at the bottom of the hut
                 if (!this.hasWitch)
                 {
-                    int x = this.getXWithOffset(2, 5);
-                    int y = this.getYWithOffset(2);
-                    int z = this.getZWithOffset(2, 5);
+                    int amount = randomIn.nextInt(3);
+                    for(int i = 0; i < amount + 1; i++) {
+                        int x = this.getXWithOffset(i * 3, 5);
+                        int y = this.getYWithOffset(2);
+                        int z = this.getZWithOffset(i * 3, 5);
 
-                    if (structureBoundingBoxIn.isVecInside(new BlockPos(x, y, z)))
-                    {
-                        //int amount = randomIn.nextInt(3);
-                        for(int i = 0; i < 3; i++) {
+                        if (structureBoundingBoxIn.isVecInside(new BlockPos(x, y, z))) {
                             EntityWitch entitywitch = new EntityWitch(worldIn);
                             entitywitch.setLocationAndAngles((double)x + 0.5D, (double)y, (double)z + 0.5D, 0.0F, 0.0F);
                             entitywitch.onInitialSpawn(worldIn.getDifficultyForLocation(new BlockPos(x, y, z)),null);
                             entitywitch.enablePersistence();
                             worldIn.spawnEntityInWorld(entitywitch);
                         }
-                        this.hasWitch = true;
                     }
+                    this.hasWitch = true;
                 }
             }
 
@@ -233,10 +231,6 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
         public boolean addComponentParts(World worldIn, Random randomIn, StructureBoundingBox structureBoundingBoxIn)
         {
             boolean result = super.addComponentParts(worldIn, randomIn, structureBoundingBoxIn);
-
-            //For finding them
-            System.out.println(this.boundingBox.minX + ", " + this.boundingBox.minY + ", " + this.boundingBox.minZ);
-
             this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 5, 4, 11, structureBoundingBoxIn);
             this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 6, 4, 11, structureBoundingBoxIn);
             this.setAir(worldIn, 6, 3, 10, structureBoundingBoxIn);

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -1,8 +1,16 @@
 package betterwithmods.world;
 
+import betterwithmods.BWMBlocks;
+import betterwithmods.blocks.BlockAesthetic;
 import betterwithmods.event.BWMWorldGenEvent;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.BlockLadder;
+import net.minecraft.block.BlockPlanks;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.monster.EntityWitch;
 import net.minecraft.init.Blocks;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.EnumFacing;
@@ -103,6 +111,136 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
             }
             else
                 this.setBlockState(worldIn, Blocks.ENCHANTING_TABLE.getDefaultState(), 10, 1, 10, structureBoundingBoxIn);
+
+            return result;
+        }
+
+        private void setAir(World world, int x, int y, int z, StructureBoundingBox structureBoundingBox) {
+            this.setBlockState(world, Blocks.AIR.getDefaultState(), x, y, z, structureBoundingBox);
+        }
+    }
+
+    public static class SwampHut extends ComponentScatteredFeaturePieces.SwampHut
+    {
+        private boolean hasWitch;
+
+        @Override
+        protected void writeStructureToNBT(NBTTagCompound tagCompound)
+        {
+            super.writeStructureToNBT(tagCompound);
+            tagCompound.setBoolean("Witch", this.hasWitch);
+        }
+
+        @Override
+        protected void readStructureFromNBT(NBTTagCompound tagCompound)
+        {
+            super.readStructureFromNBT(tagCompound);
+            this.hasWitch = tagCompound.getBoolean("Witch");
+        }
+
+        public SwampHut(Random p_i2066_1_, int p_i2066_2_, int p_i2066_3_)
+        {
+            super(p_i2066_1_, p_i2066_2_, p_i2066_3_);
+        }
+
+        @Override
+        public boolean addComponentParts(World worldIn, Random randomIn, StructureBoundingBox structureBoundingBoxIn)
+        {
+            if (!this.offsetToAverageGroundLevel(worldIn, structureBoundingBoxIn, 0))
+            {
+                return false;
+            }
+            else
+            {
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 1, 1, 1, 5, 1, 7, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 1, 4, 2, 5, 4, 7, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 2, 1, 0, 4, 1, 0, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 2, 2, 2, 3, 3, 2, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 1, 2, 3, 1, 3, 6, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 5, 2, 3, 5, 3, 6, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 2, 2, 7, 4, 3, 7, Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), Blocks.PLANKS.getStateFromMeta(BlockPlanks.EnumType.SPRUCE.getMetadata()), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 1, 0, 2, 1, 3, 2, Blocks.LOG.getDefaultState(), Blocks.LOG.getDefaultState(), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 5, 0, 2, 5, 3, 2, Blocks.LOG.getDefaultState(), Blocks.LOG.getDefaultState(), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 1, 0, 7, 1, 3, 7, Blocks.LOG.getDefaultState(), Blocks.LOG.getDefaultState(), false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 5, 0, 7, 5, 3, 7, Blocks.LOG.getDefaultState(), Blocks.LOG.getDefaultState(), false);
+                this.setBlockState(worldIn, Blocks.OAK_FENCE.getDefaultState(), 2, 3, 2, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OAK_FENCE.getDefaultState(), 3, 3, 7, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.AIR.getDefaultState(), 1, 3, 4, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.AIR.getDefaultState(), 5, 3, 4, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.AIR.getDefaultState(), 5, 3, 5, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.FLOWER_POT.getDefaultState().withProperty(BlockFlowerPot.CONTENTS, BlockFlowerPot.EnumFlowerType.MUSHROOM_RED), 1, 3, 5, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.CRAFTING_TABLE.getDefaultState(), 3, 2, 6, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.CAULDRON.getDefaultState(), 4, 2, 6, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OAK_FENCE.getDefaultState(), 1, 2, 1, structureBoundingBoxIn);
+                this.setBlockState(worldIn, Blocks.OAK_FENCE.getDefaultState(), 5, 2, 1, structureBoundingBoxIn);
+                IBlockState iblockstate = Blocks.SPRUCE_STAIRS.getDefaultState().withProperty(BlockStairs.FACING, EnumFacing.NORTH);
+                IBlockState iblockstate1 = Blocks.SPRUCE_STAIRS.getDefaultState().withProperty(BlockStairs.FACING, EnumFacing.EAST);
+                IBlockState iblockstate2 = Blocks.SPRUCE_STAIRS.getDefaultState().withProperty(BlockStairs.FACING, EnumFacing.WEST);
+                IBlockState iblockstate3 = Blocks.SPRUCE_STAIRS.getDefaultState().withProperty(BlockStairs.FACING, EnumFacing.SOUTH);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 0, 4, 1, 6, 4, 1, iblockstate, iblockstate, false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 0, 4, 2, 0, 4, 7, iblockstate1, iblockstate1, false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 6, 4, 2, 6, 4, 7, iblockstate2, iblockstate2, false);
+                this.fillWithBlocks(worldIn, structureBoundingBoxIn, 0, 4, 8, 6, 4, 8, iblockstate3, iblockstate3, false);
+
+                for (int i = 2; i <= 7; i += 5)
+                {
+                    for (int j = 1; j <= 5; j += 4)
+                    {
+                        this.replaceAirAndLiquidDownwards(worldIn, Blocks.LOG.getDefaultState(), j, -1, i, structureBoundingBoxIn);
+                    }
+                }
+
+                //TODO have witches spawn randomly around hut instead of same spot. or at least have two at the bottom of the hut
+                if (!this.hasWitch)
+                {
+                    int x = this.getXWithOffset(2, 5);
+                    int y = this.getYWithOffset(2);
+                    int z = this.getZWithOffset(2, 5);
+
+                    if (structureBoundingBoxIn.isVecInside(new BlockPos(x, y, z)))
+                    {
+                        //int amount = randomIn.nextInt(3);
+                        for(int i = 0; i < 3; i++) {
+                            EntityWitch entitywitch = new EntityWitch(worldIn);
+                            entitywitch.setLocationAndAngles((double)x + 0.5D, (double)y, (double)z + 0.5D, 0.0F, 0.0F);
+                            entitywitch.onInitialSpawn(worldIn.getDifficultyForLocation(new BlockPos(x, y, z)),null);
+                            entitywitch.enablePersistence();
+                            worldIn.spawnEntityInWorld(entitywitch);
+                        }
+                        this.hasWitch = true;
+                    }
+                }
+            }
+
+            this.setBlockState(worldIn, Blocks.PLANKS.getDefaultState().withProperty(BlockPlanks.VARIANT, BlockPlanks.EnumType.SPRUCE), 2, 2, 6, structureBoundingBoxIn);
+            this.setBlockState(worldIn, Blocks.BREWING_STAND.getDefaultState(), 2, 3, 6, structureBoundingBoxIn);
+
+            return true;
+        }
+    }
+
+    public static class JunglePyramid extends ComponentScatteredFeaturePieces.JunglePyramid
+    {
+        JunglePyramid(Random rand, int x, int z)
+        {
+            super(rand, x, z);
+        }
+
+        @Override
+        public boolean addComponentParts(World worldIn, Random randomIn, StructureBoundingBox structureBoundingBoxIn)
+        {
+            boolean result = super.addComponentParts(worldIn, randomIn, structureBoundingBoxIn);
+
+            //For finding them
+            System.out.println(this.boundingBox.minX + ", " + this.boundingBox.minY + ", " + this.boundingBox.minZ);
+
+            this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 5, 4, 11, structureBoundingBoxIn);
+            this.setBlockState(worldIn, BWMBlocks.AESTHETIC.getDefaultState().withProperty(BlockAesthetic.blockType, BlockAesthetic.EnumType.CHOPBLOCKBLOOD), 6, 4, 11, structureBoundingBoxIn);
+            //TODO add Vessel of the Dragon
+            this.setAir(worldIn, 6, 3, 10, structureBoundingBoxIn);
+            this.setBlockState(worldIn, BWMBlocks.HAND_CRANK.getDefaultState(), 5, 3, 10, structureBoundingBoxIn);
+
+            //TODO remove tripwire, remove chest loot, center lever & wall. change dispensers to have either rotten or poison arrows?
 
             return result;
         }

--- a/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
+++ b/src/main/java/betterwithmods/world/BWComponentScatteredFeaturePieces.java
@@ -104,7 +104,6 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
                     int l1 = enumfacing.getFrontOffsetZ() * 2;
                     TileEntity tileentity = worldIn.getTileEntity(new BlockPos(this.getXWithOffset(10 + k1, 10 + l1), this.getYWithOffset(-11), this.getZWithOffset(10 + k1, 10 + l1)));
                     if (tileentity instanceof TileEntityChest)
-                        //TODO create desert temple loot table that only has rotten flesh and bones?
                         ((TileEntityChest)tileentity).setLootTable(null, randomIn.nextLong());
                 }
             }
@@ -271,7 +270,6 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
                 this.setBlockState(worldIn, BWMBlocks.HAND_CRANK.getDefaultState(), 5, 3, 10, structureBoundingBoxIn);
                 //TODO add Vessel of the Dragon @ 6, 3, 10
             }
-            //TODO change dispensers to have either rotten or poison arrows?
 
             return result;
         }
@@ -283,7 +281,6 @@ public class BWComponentScatteredFeaturePieces extends ComponentScatteredFeature
         private void removeChest(World worldIn, int x, int y, int z, Random randomIn) {
             TileEntity tileentity = worldIn.getTileEntity(new BlockPos(this.getXWithOffset(x, z), this.getYWithOffset(y), this.getZWithOffset(x, z)));
             if (tileentity instanceof TileEntityChest)
-                //TODO create jungle temple loot table?
                 ((TileEntityChest)tileentity).setLootTable(null, randomIn.nextLong());
         }
     }

--- a/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
+++ b/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
@@ -22,6 +22,10 @@ public class BWMapGenScatteredFeature extends MapGenScatteredFeature {
 
     public static class Start extends MapGenScatteredFeature.Start
     {
+        public Start()
+        {
+        }
+
         Start(World worldIn, Random random, int chunkX, int chunkZ)
         {
             this(worldIn, random, chunkX, chunkZ, worldIn.getBiome(new BlockPos(chunkX * 16 + 8, 0, chunkZ * 16 + 8)));

--- a/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
+++ b/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
@@ -1,0 +1,62 @@
+package betterwithmods.world;
+
+import net.minecraft.init.Biomes;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.structure.MapGenScatteredFeature;
+import net.minecraft.world.gen.structure.StructureStart;
+
+import java.util.Random;
+
+/**
+ * Created by blueyu2 on 11/27/16.
+ */
+public class BWMapGenScatteredFeature extends MapGenScatteredFeature {
+
+    @Override
+    protected StructureStart getStructureStart(int chunkX, int chunkZ)
+    {
+        return new BWMapGenScatteredFeature.Start(this.worldObj, this.rand, chunkX, chunkZ);
+    }
+
+    public static class Start extends MapGenScatteredFeature.Start
+    {
+        Start(World worldIn, Random random, int chunkX, int chunkZ)
+        {
+            this(worldIn, random, chunkX, chunkZ, worldIn.getBiome(new BlockPos(chunkX * 16 + 8, 0, chunkZ * 16 + 8)));
+        }
+
+        Start(World worldIn, Random random, int chunkX, int chunkZ, Biome biomeIn)
+        {
+            if (biomeIn != Biomes.JUNGLE && biomeIn != Biomes.JUNGLE_HILLS)
+            {
+                if (biomeIn == Biomes.SWAMPLAND)
+                {
+                    BWComponentScatteredFeaturePieces.SwampHut componentscatteredfeaturepieces$swamphut = new BWComponentScatteredFeaturePieces.SwampHut(random, chunkX * 16, chunkZ * 16);
+                    this.components.add(componentscatteredfeaturepieces$swamphut);
+                }
+                else if (biomeIn != Biomes.DESERT && biomeIn != Biomes.DESERT_HILLS)
+                {
+                    if (biomeIn == Biomes.ICE_PLAINS || biomeIn == Biomes.COLD_TAIGA)
+                    {
+                        BWComponentScatteredFeaturePieces.Igloo componentscatteredfeaturepieces$igloo = new BWComponentScatteredFeaturePieces.Igloo(random, chunkX * 16, chunkZ * 16);
+                        this.components.add(componentscatteredfeaturepieces$igloo);
+                    }
+                }
+                else
+                {
+                    BWComponentScatteredFeaturePieces.DesertPyramid componentscatteredfeaturepieces$desertpyramid = new BWComponentScatteredFeaturePieces.DesertPyramid(random, chunkX * 16, chunkZ * 16);
+                    this.components.add(componentscatteredfeaturepieces$desertpyramid);
+                }
+            }
+            else
+            {
+                BWComponentScatteredFeaturePieces.JunglePyramid componentscatteredfeaturepieces$junglepyramid = new BWComponentScatteredFeaturePieces.JunglePyramid(random, chunkX * 16, chunkZ * 16);
+                this.components.add(componentscatteredfeaturepieces$junglepyramid);
+            }
+
+            this.updateBoundingBox();
+        }
+    }
+}

--- a/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
+++ b/src/main/java/betterwithmods/world/BWMapGenScatteredFeature.java
@@ -37,27 +37,27 @@ public class BWMapGenScatteredFeature extends MapGenScatteredFeature {
             {
                 if (biomeIn == Biomes.SWAMPLAND)
                 {
-                    BWComponentScatteredFeaturePieces.SwampHut componentscatteredfeaturepieces$swamphut = new BWComponentScatteredFeaturePieces.SwampHut(random, chunkX * 16, chunkZ * 16);
-                    this.components.add(componentscatteredfeaturepieces$swamphut);
+                    BWComponentScatteredFeaturePieces.SwampHut swampHut = new BWComponentScatteredFeaturePieces.SwampHut(random, chunkX * 16, chunkZ * 16);
+                    this.components.add(swampHut);
                 }
                 else if (biomeIn != Biomes.DESERT && biomeIn != Biomes.DESERT_HILLS)
                 {
                     if (biomeIn == Biomes.ICE_PLAINS || biomeIn == Biomes.COLD_TAIGA)
                     {
-                        BWComponentScatteredFeaturePieces.Igloo componentscatteredfeaturepieces$igloo = new BWComponentScatteredFeaturePieces.Igloo(random, chunkX * 16, chunkZ * 16);
-                        this.components.add(componentscatteredfeaturepieces$igloo);
+                        BWComponentScatteredFeaturePieces.Igloo igloo = new BWComponentScatteredFeaturePieces.Igloo(random, chunkX * 16, chunkZ * 16);
+                        this.components.add(igloo);
                     }
                 }
                 else
                 {
-                    BWComponentScatteredFeaturePieces.DesertPyramid componentscatteredfeaturepieces$desertpyramid = new BWComponentScatteredFeaturePieces.DesertPyramid(random, chunkX * 16, chunkZ * 16);
-                    this.components.add(componentscatteredfeaturepieces$desertpyramid);
+                    BWComponentScatteredFeaturePieces.DesertPyramid desertPyramid = new BWComponentScatteredFeaturePieces.DesertPyramid(random, chunkX * 16, chunkZ * 16);
+                    this.components.add(desertPyramid);
                 }
             }
             else
             {
-                BWComponentScatteredFeaturePieces.JunglePyramid componentscatteredfeaturepieces$junglepyramid = new BWComponentScatteredFeaturePieces.JunglePyramid(random, chunkX * 16, chunkZ * 16);
-                this.components.add(componentscatteredfeaturepieces$junglepyramid);
+                BWComponentScatteredFeaturePieces.JunglePyramid junglePyramid = new BWComponentScatteredFeaturePieces.JunglePyramid(random, chunkX * 16, chunkZ * 16);
+                this.components.add(junglePyramid);
             }
 
             this.updateBoundingBox();


### PR DESCRIPTION
Adds Hardcore Structures config option

Pyramid:
Replaces Hardened Clay with Obsidian
Adds Enchanting Table if outside respawn radius
Removes chest loot, pressure plate, and TNT if inside respawn radius.

Jungle Temple:
Removes Tripwire, chest loot, and center of puzzle if inside respawn radius
Adds Bloodied Chopping Blocks
Adds Hand Crank if outside respawn radius (Need Vessel of the Dragon)

Swamp Hut:
Adds Brewing Stand
Adds additional Witch spawns to Swamp Hut, and makes them persistent

Removes recipes for the Enchanting Table and Brewing Stand