### PR TITLE
Various Recipe Changes

### DIFF
--- a/src/main/java/betterwithmods/BWCrafting.java
+++ b/src/main/java/betterwithmods/BWCrafting.java
@@ -68,10 +68,18 @@ public class BWCrafting {
         GameRegistry.addRecipe(new ShapedOreRecipe(Blocks.NETHER_BRICK_STAIRS, "M ", "MM", 'M', new ItemStack(BWMBlocks.STONE_MOULDING, 1, BlockMini.EnumType.NETHERBRICK.getMetadata())).setMirrored(true));
         GameRegistry.addRecipe(new ShapedOreRecipe(Blocks.BRICK_STAIRS, "M ", "MM", 'M', new ItemStack(BWMBlocks.STONE_MOULDING, 1, BlockMini.EnumType.BRICK.getMetadata())).setMirrored(true));
         GameRegistry.addRecipe(new ShapedOreRecipe(Blocks.SANDSTONE_STAIRS, "M ", "MM", 'M', new ItemStack(BWMBlocks.STONE_MOULDING, 1, BlockMini.EnumType.SANDSTONE.getMetadata())).setMirrored(true));
-        for (int i = 0; i < 4; i++)
-            GameRegistry.addShapelessRecipe(new ItemStack(Blocks.PLANKS, 3, i), new ItemStack(BWMBlocks.DEBARKED_OLD, 1, i));
-        for (int i = 0; i < 2; i++)
-            GameRegistry.addShapelessRecipe(new ItemStack(Blocks.PLANKS, 3, 4 + i), new ItemStack(BWMBlocks.DEBARKED_NEW, 1, i));
+        if(BWConfig.hardcoreLumber) {
+            for (int i = 0; i < 4; i++)
+                GameRegistry.addRecipe(new ChoppingRecipe(new ItemStack(Blocks.PLANKS, 1, i), null, ItemMaterial.getMaterial("sawdust", 2), new ItemStack(BWMBlocks.DEBARKED_OLD, 1, i)));
+            for (int i = 0; i < 2; i++)
+                GameRegistry.addRecipe(new ChoppingRecipe(new ItemStack(Blocks.PLANKS, 1, 4 + i), null, ItemMaterial.getMaterial("sawdust", 2), new ItemStack(BWMBlocks.DEBARKED_NEW, 1, i)));
+        }
+        else {
+            for (int i = 0; i < 4; i++)
+                GameRegistry.addShapelessRecipe(new ItemStack(Blocks.PLANKS, 3, i), new ItemStack(BWMBlocks.DEBARKED_OLD, 1, i));
+            for (int i = 0; i < 2; i++)
+                GameRegistry.addShapelessRecipe(new ItemStack(Blocks.PLANKS, 3, 4 + i), new ItemStack(BWMBlocks.DEBARKED_NEW, 1, i));
+        }
         GameRegistry.addShapedRecipe(new ItemStack(Blocks.BOOKSHELF), "SSS", "BBB", "SSS", 'S', new ItemStack(BWMBlocks.WOOD_SIDING, 1, OreDictionary.WILDCARD_VALUE), 'B', Items.BOOK);
         GameRegistry.addShapedRecipe(new ItemStack(Blocks.CHEST), "SSS", "S S", "SSS", 'S', new ItemStack(BWMBlocks.WOOD_SIDING, 1, OreDictionary.WILDCARD_VALUE));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Blocks.NOTEBLOCK), "SSS", "SRS", "SSS", 'S', new ItemStack(BWMBlocks.WOOD_SIDING, 1, OreDictionary.WILDCARD_VALUE), 'R', "dustRedstone"));
@@ -155,7 +163,7 @@ public class BWCrafting {
         GameRegistry.addRecipe(new ShapedOreRecipe(ItemMaterial.getMaterial("windmill_blade"), "CCC", "CCC", "WWW", 'W', "slabWood", 'C', "fabricHemp"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMBlocks.ANCHOR), " I ", "SSS", 'S', "stone", 'I', "ingotIron"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMBlocks.HIBACHI), "HHH", "SES", "SRS", 'S', "stone", 'R', "dustRedstone", 'H', ItemMaterial.getMaterial("concentrated_hellfire"), 'E', ItemMaterial.getMaterial("element")));
-        GameRegistry.addRecipe(new ShapelessOreRecipe(ItemMaterial.getMaterial("leather_strap", 4), "craftingToolKnife", ItemMaterial.getMaterial("tanned_leather_cut")));
+        GameRegistry.addRecipe(new CuttingRecipe(ItemMaterial.getMaterial("leather_strap", 4), ItemMaterial.getMaterial("tanned_leather_cut")));
         GameRegistry.addRecipe(new ShapedOreRecipe(ItemMaterial.getMaterial("leather_belt"), " L ", "L L", " L ", 'L', ItemMaterial.getMaterial("leather_strap")));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMBlocks.BELLOWS), "WWW", "LLL", "BGB", 'W', new ItemStack(BWMBlocks.WOOD_SIDING, 1, OreDictionary.WILDCARD_VALUE), 'L', ItemMaterial.getMaterial("tanned_leather_cut"), 'B', ItemMaterial.getMaterial("leather_belt"), 'G', "gearWood"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMBlocks.GEARBOX), "PGP", "GLG", "PGP", 'P', "plankWood", 'G', "gearWood", 'L', ItemMaterial.getMaterial("redstone_latch")));
@@ -191,9 +199,9 @@ public class BWCrafting {
         //GameRegistry.addRecipe(new ShapelessOreRecipe(new ItemStack(Items.GUNPOWDER, 2, 0), new Object[] {"dustSulfur", "dustSaltpeter", "dustCharcoal"}));
         GameRegistry.addRecipe(new ShapedOreRecipe(ItemMaterial.getMaterial("redstone_latch"), "GGG", " R ", 'G', "nuggetGold", 'R', "dustRedstone"));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMBlocks.ROPE), "XX", "XX", "XX", 'X', "fiberHemp"));
-        GameRegistry.addRecipe(new ShapelessOreRecipe(ItemMaterial.getMaterial("leather_cut", 2), Items.LEATHER, "craftingToolKnife"));
-        GameRegistry.addRecipe(new ShapelessOreRecipe(ItemMaterial.getMaterial("tanned_leather_cut", 2), ItemMaterial.getMaterial("tanned_leather"), "craftingToolKnife"));
-        GameRegistry.addRecipe(new ShapelessOreRecipe(ItemMaterial.getMaterial("scoured_leather_cut", 2), ItemMaterial.getMaterial("scoured_leather"), "craftingToolKnife"));
+        GameRegistry.addRecipe(new CuttingRecipe(ItemMaterial.getMaterial("leather_cut", 2), new ItemStack(Items.LEATHER)));
+        GameRegistry.addRecipe(new CuttingRecipe(ItemMaterial.getMaterial("tanned_leather_cut", 2), ItemMaterial.getMaterial("tanned_leather")));
+        GameRegistry.addRecipe(new CuttingRecipe(ItemMaterial.getMaterial("scoured_leather_cut", 2), ItemMaterial.getMaterial("scoured_leather")));
         GameRegistry.addRecipe(new ShapedOreRecipe(ItemMaterial.getMaterial("sharpening_stone"), "X ", " X", 'X', Items.FLINT).setMirrored(true));
         GameRegistry.addRecipe(new ShapedOreRecipe(ItemMaterial.getMaterial("knife_blade"), "I ", " X", 'X', ItemMaterial.getMaterial("sharpening_stone"), 'I', "ingotIron").setMirrored(true));
         GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(BWMItems.KNIFE), "I ", " X", 'X', "stickWood", 'I', ItemMaterial.getMaterial("knife_blade")).setMirrored(true));

--- a/src/main/java/betterwithmods/BWFuelHandler.java
+++ b/src/main/java/betterwithmods/BWFuelHandler.java
@@ -1,5 +1,6 @@
 package betterwithmods;
 
+import betterwithmods.items.ItemMaterial;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.IFuelHandler;
@@ -12,8 +13,12 @@ public class BWFuelHandler implements IFuelHandler {
         int meta = fuel.getItemDamage();
         if (item == BWMItems.MATERIAL && meta == 1)
             return 3200;
+        else if (item == BWMItems.MATERIAL && meta == 22)
+            return 25;
+        else if (item == BWMItems.MATERIAL && meta == 23)
+            return 25;
         else if (item == BWMItems.BARK)
-            return 100;
+            return 25;
         else if (item == Item.getItemFromBlock(BWMBlocks.WOOD_SIDING))
             return 150;
         else if (item == Item.getItemFromBlock(BWMBlocks.WOOD_MOULDING))

--- a/src/main/java/betterwithmods/BWRegistry.java
+++ b/src/main/java/betterwithmods/BWRegistry.java
@@ -5,6 +5,7 @@ import betterwithmods.blocks.BlockBDispenser;
 import betterwithmods.blocks.BlockBWMPane;
 import betterwithmods.blocks.BlockRope;
 import betterwithmods.config.BWConfig;
+import betterwithmods.craft.ChoppingRecipe;
 import betterwithmods.craft.HopperFilters;
 import betterwithmods.craft.SawInteraction;
 import betterwithmods.craft.heat.BWMHeatRegistry;
@@ -24,6 +25,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.*;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.item.crafting.ShapelessRecipes;
 import net.minecraft.potion.Potion;
 import net.minecraft.util.EnumFacing;
@@ -36,6 +38,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class BWRegistry {
@@ -177,7 +180,7 @@ public class BWRegistry {
     public static void registerWood() {
         for (BlockPlanks.EnumType type : BlockPlanks.EnumType.values()) {
             ItemStack log;
-            ItemStack plank = new ItemStack(Blocks.PLANKS, 6, type.getMetadata());
+            ItemStack plank = new ItemStack(Blocks.PLANKS, BWConfig.hardcoreLumber ? 4 : 6, type.getMetadata());
             if (type.getMetadata() < 4) {
                 log = new ItemStack(Blocks.LOG, 1, type.getMetadata());
 
@@ -185,12 +188,16 @@ public class BWRegistry {
                 log = new ItemStack(Blocks.LOG2, 1, type.getMetadata() - 4);
             }
             Block block = ((ItemBlock) log.getItem()).getBlock();
-            ItemStack bark = new ItemStack(BWMItems.BARK, 2, type.getMetadata());
+            ItemStack bark = new ItemStack(BWMItems.BARK, 1, type.getMetadata());
             ItemStack sawdust = ItemMaterial.getMaterial("sawdust", 2);
+            if (BWConfig.hardcoreLumber) {
+                removeRecipe(plank, log);
+                GameRegistry.addRecipe(new ChoppingRecipe(new ItemStack(Blocks.PLANKS, 2, type.getMetadata()), bark, sawdust, log));
+            }
             SawInteraction.INSTANCE.addRecipe(block, log.getMetadata(), plank, bark, sawdust);
             SawInteraction.INSTANCE.addRecipe(Blocks.PLANKS, type.getMetadata(),
                     new ItemStack(BWMBlocks.WOOD_SIDING, 2, type.getMetadata()));
-            plank = new ItemStack(Blocks.PLANKS, 5, type.getMetadata());
+            plank = new ItemStack(Blocks.PLANKS, BWConfig.hardcoreLumber ? 3 : 5, type.getMetadata());
             if (type.getMetadata() < 4) {
                 log = new ItemStack(BWMBlocks.DEBARKED_OLD, 1, type.getMetadata());
             } else {
@@ -210,9 +217,13 @@ public class BWRegistry {
                             ItemStack planks = getRecipeOutput(new ItemStack(log.getItem(), 1, i));
                             if (planks != null) {
                                 ItemStack[] output = new ItemStack[3];
-                                output[0] = new ItemStack(planks.getItem(), 6, planks.getMetadata());
-                                output[1] = new ItemStack(BWMItems.BARK, 2, 0);
-                                output[2] = ItemMaterial.getMaterial("sawdust");
+                                output[0] = new ItemStack(planks.getItem(), BWConfig.hardcoreLumber ? 4 : 6, planks.getMetadata());
+                                output[1] = new ItemStack(BWMItems.BARK, 1, 0);
+                                output[2] = ItemMaterial.getMaterial("sawdust", 2);
+                                if (BWConfig.hardcoreLumber) {
+                                    removeRecipe(output[0], log);
+                                    GameRegistry.addRecipe(new ChoppingRecipe(new ItemStack(planks.getItem(), 2, planks.getMetadata()), output[1], output[2], log));
+                                }
                                 SawInteraction.INSTANCE.addRecipe(block, i, output);
                                 SawInteraction.INSTANCE.addRecipe(planks, new ItemStack(BWMBlocks.WOOD_SIDING, 2, 0));
                             }
@@ -221,9 +232,13 @@ public class BWRegistry {
                         ItemStack planks = getRecipeOutput(log);
                         if (planks != null) {
                             ItemStack[] output = new ItemStack[3];
-                            output[0] = new ItemStack(planks.getItem(), 6, planks.getMetadata());
-                            output[1] = new ItemStack(BWMItems.BARK, 2, 0);
-                            output[2] = ItemMaterial.getMaterial("sawdust");
+                            output[0] = new ItemStack(planks.getItem(), BWConfig.hardcoreLumber ? 4 : 6, planks.getMetadata());
+                            output[1] = new ItemStack(BWMItems.BARK, 1, 0);
+                            output[2] = ItemMaterial.getMaterial("sawdust", 2);
+                            if (BWConfig.hardcoreLumber) {
+                                removeRecipe(output[0], log);
+                                GameRegistry.addRecipe(new ChoppingRecipe(new ItemStack(planks.getItem(), 2, planks.getMetadata()), output[1], output[2], log));
+                            }
                             SawInteraction.INSTANCE.addRecipe(block, log.getMetadata(), output);
                             SawInteraction.INSTANCE.addRecipe(planks, new ItemStack(BWMBlocks.WOOD_SIDING, 2, 0));
                         }
@@ -254,6 +269,42 @@ public class BWRegistry {
             }
         }
         return null;
+    }
+
+    private static void removeRecipe(ItemStack output, ItemStack input) {
+        List<IRecipe> recipes = CraftingManager.getInstance().getRecipeList();
+        List<IRecipe> toRemove = new ArrayList<>();
+        for (IRecipe recipe : recipes) {
+            if (recipe instanceof ShapedRecipes) {
+                ShapedRecipes shaped = (ShapedRecipes) recipe;
+                if (shaped.getRecipeSize() == 1) {
+                    if (shaped.recipeItems[0].isItemEqual(input)) {
+                        if(output.isItemEqual(shaped.getRecipeOutput()))
+                            toRemove.add(recipe);
+                    }
+                }
+            }
+            else if (recipe instanceof ShapelessRecipes) {
+                ShapelessRecipes shapeless = (ShapelessRecipes) recipe;
+                if (shapeless.recipeItems.size() == 1 && shapeless.recipeItems.get(0).isItemEqual(input)) {
+                    if(output.isItemEqual(shapeless.getRecipeOutput()))
+                        toRemove.add(recipe);
+                }
+            } else if (recipe instanceof ShapelessOreRecipe) {
+                ShapelessOreRecipe shapeless = (ShapelessOreRecipe) recipe;
+                if (shapeless.getRecipeSize() == 1) {
+                    if (shapeless.getInput().get(0) instanceof ItemStack) {
+                        if (((ItemStack) shapeless.getInput().get(0)).isItemEqual(input)) {
+                            if(output.isItemEqual(shapeless.getRecipeOutput()))
+                                toRemove.add(recipe);
+                        }
+                    }
+                }
+            }
+        }
+        for(IRecipe remove : toRemove) {
+            CraftingManager.getInstance().getRecipeList().remove(remove);
+        }
     }
 
     private static void registerPotions() {

--- a/src/main/java/betterwithmods/config/BWConfig.java
+++ b/src/main/java/betterwithmods/config/BWConfig.java
@@ -71,7 +71,7 @@ public class BWConfig {
     private static void syncConfig() {
         HARDCORE_CAT = config.getCategory(HARDCORE);
         hardcoreGunpowder = config.get(HARDCORE, "Hardcore Gunpowder", true, "Creepers and Ghasts will drop brimstone or niter instead of gunpowder").getBoolean();
-        hardcoreLumber = config.get(HARDCORE, "Hardcore Lumberjack", true, "Logs break into planks if you don't use an axe").getBoolean();
+        hardcoreLumber = config.get(HARDCORE, "Hardcore Lumberjack", true, "Logs break into planks if you don't use an axe. Need an axe to chop logs into planks").setRequiresMcRestart(true).getBoolean();
         hardcoreBuckets = config.get(HARDCORE, "Hardcore Buckets", true, "Water sources cannot be moved outside the End").getBoolean();
         hardcoreMelons = config.get(HARDCORE, "Hardcore Melons", true, "Melons and pumpkins are affected by gravity and need a saw to slice up.").getBoolean();
         hardcoreFluidContainer = config.get(HARDCORE, "Hardcore Buckets Affects Modded Fluid Containers", true).getBoolean();

--- a/src/main/java/betterwithmods/craft/ChoppingRecipe.java
+++ b/src/main/java/betterwithmods/craft/ChoppingRecipe.java
@@ -1,0 +1,121 @@
+package betterwithmods.craft;
+
+import net.minecraft.init.Items;
+import net.minecraft.init.SoundEvents;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import java.util.Random;
+
+/**
+ * Created by blueyu2 on 12/12/16.
+ */
+public class ChoppingRecipe extends ShapelessOreRecipe {
+    private final ItemStack log, bark, sawdust;
+
+    public ChoppingRecipe(ItemStack planks, ItemStack bark, ItemStack sawdust, ItemStack log) {
+        super(planks, new ItemStack(Items.IRON_AXE, 1, OreDictionary.WILDCARD_VALUE), log);
+        this.log = log;
+        this.bark = bark;
+        this.sawdust = sawdust;
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting inv, World worldIn) {
+        return isMatch(inv);
+    }
+
+    public boolean isMatch(IInventory inventory) {
+        boolean hasAxe = false;
+        boolean hasLog = false;
+
+        for (int x = 0; x < inventory.getSizeInventory(); x++)
+        {
+            boolean inRecipe = false;
+            ItemStack slot = inventory.getStackInSlot(x);
+
+            if (slot != null) {
+                if (isAxe(slot)) {
+                    if(!hasAxe) {
+                        hasAxe = true;
+                        inRecipe = true;
+                    }
+                    else
+                        return false;
+                }
+                else if (OreDictionary.itemMatches(slot, log, true)) {
+                    if(!hasLog) {
+                        hasLog = true;
+                        inRecipe = true;
+                    }
+                    else
+                        return false;
+                }
+                if(!inRecipe)
+                    return false;
+            }
+        }
+        return hasAxe && hasLog;
+    }
+
+    private boolean isAxe(ItemStack stack) {
+        if (stack != null) {
+            if (stack.getItem().getToolClasses(stack).contains("axe")) {
+                if(stack.getItem().getRegistryName().getResourceDomain().equals("tconstruct")) {
+                    if (stack.getItemDamage() >= stack.getMaxDamage())
+                        return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public ItemStack[] getRemainingItems(InventoryCrafting inv) {
+        ItemStack[] ret = new ItemStack[inv.getSizeInventory()];
+        for (int i = 0; i < ret.length; i++)
+        {
+            ItemStack stack = inv.getStackInSlot(i);
+            if(stack != null && isAxe(stack)) {
+                ItemStack copy = stack.copy();
+                if(copy.getItem().getHarvestLevel(copy, "axe", null, null) > 1) {
+                    ret[i] = copy;
+                }
+                else if (!copy.attemptDamageItem(1, new Random())) {
+                    ret[i] = copy;
+                }
+                else if (copy.getItem().getRegistryName().getResourceDomain().equals("tconstruct")) {
+                    ret[i] = copy;
+                }
+            }
+        }
+        return ret;
+    }
+
+    @SubscribeEvent
+    public void dropExtra(PlayerEvent.ItemCraftedEvent event) {
+        if(event.player == null)
+            return;
+
+        if(isMatch(event.craftMatrix))
+        {
+            if(!event.player.getEntityWorld().isRemote) {
+                if (sawdust != null)
+                    event.player.entityDropItem(sawdust, 0);
+                if (bark != null)
+                    event.player.entityDropItem(bark, 0);
+            }
+            else
+                event.player.playSound(SoundEvents.ENTITY_ZOMBIE_ATTACK_DOOR_WOOD, 0.25F, 2.5F);
+        }
+    }
+}

--- a/src/main/java/betterwithmods/craft/CuttingRecipe.java
+++ b/src/main/java/betterwithmods/craft/CuttingRecipe.java
@@ -1,0 +1,81 @@
+package betterwithmods.craft;
+
+import net.minecraft.init.Items;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemShears;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.oredict.OreDictionary;
+import net.minecraftforge.oredict.ShapelessOreRecipe;
+
+import java.util.Random;
+
+/**
+ * Created by blueyu2 on 12/12/16.
+ */
+public class CuttingRecipe extends ShapelessOreRecipe {
+    private final ItemStack input;
+
+    public CuttingRecipe(ItemStack result, ItemStack input) {
+        super(result, new ItemStack(Items.SHEARS, 1, OreDictionary.WILDCARD_VALUE), input);
+        this.input = input;
+    }
+
+    @Override
+    public boolean matches(InventoryCrafting inv, World worldIn) {
+        boolean hasShears = false;
+        boolean hasInput = false;
+
+        for (int x = 0; x < inv.getSizeInventory(); x++)
+        {
+            boolean inRecipe = false;
+            ItemStack slot = inv.getStackInSlot(x);
+
+            if (slot != null) {
+                if (isShears(slot)) {
+                    if(!hasShears) {
+                        hasShears = true;
+                        inRecipe = true;
+                    }
+                    else
+                        return false;
+                }
+                else if (OreDictionary.itemMatches(slot, input, true)) {
+                    if(!hasInput) {
+                        hasInput = true;
+                        inRecipe = true;
+                    }
+                    else
+                        return false;
+                }
+                if(!inRecipe)
+                    return false;
+            }
+        }
+        return hasShears && hasInput;
+    }
+
+    private boolean isShears(ItemStack stack) {
+        if (stack != null) {
+            if (stack.getItem() instanceof ItemShears)
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ItemStack[] getRemainingItems(InventoryCrafting inv) {
+        ItemStack[] ret = new ItemStack[inv.getSizeInventory()];
+        for (int i = 0; i < ret.length; i++)
+        {
+            ItemStack stack = inv.getStackInSlot(i);
+            if(stack != null && isShears(stack)) {
+                ItemStack copy = stack.copy();
+                if (!copy.attemptDamageItem(1, new Random())) {
+                    ret[i] = copy;
+                }
+            }
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
Hardcore Lumber:
- Replace default log crafting recipes to require an axe. Any axe with a harvest level of stone and under take damage. Sawdust and bark are dropped when crafted
- Reduce saw output from 6 to 4

Replace leather cutting recipes to use shears instead of a knife
Tweaked amount of sawdust and bark you receive from chopping/sawing logs
Added sawdust and soul dust burn times and tweaked bark burn time