### PR TITLE
[1.10.2] dupe bug fix + water bucket on torch fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     deobfCompile "com.blamejared:MTLib:1.+"
     runtime "MineTweaker3:MineTweaker3-MC1102-Main:+"
 
-    deobfCompile "blusunrize:ImmersiveEngineering:0.10-50-+:deobf"
+    deobfCompile "blusunrize:ImmersiveEngineering:0.10-50-+"
 }
 
 jar {

--- a/src/main/java/betterwithmods/blocks/tile/TileEntityFilteredHopper.java
+++ b/src/main/java/betterwithmods/blocks/tile/TileEntityFilteredHopper.java
@@ -336,13 +336,16 @@ public class TileEntityFilteredHopper extends TileEntityVisibleInventory impleme
                             if (leftover == null) {
                                 inventory.extractItem(stackIndex, ejectStackSize, false);
                                 break;
+                            } else {
+                                inventory.extractItem(stackIndex, ejectStack.stackSize - leftover.stackSize, false);
+                                ejectStack = leftover;
                             }
                         }
 
 
                     } else if (tile != null) {
-                        if (InvUtils.addItemStackToInv(inventory, ejectStack))
-                            inventory.extractItem(stackIndex, ejectStackSize, false);
+                        if (InvUtils.addItemStackToInv(inventory, ejectStack) || ejectStack.stackSize != ejectStackSize)
+                            inventory.extractItem(stackIndex, ejectStackSize - ejectStack.stackSize, false);
                     } else
                         this.outputBlocked = true;
                 }
@@ -354,8 +357,8 @@ public class TileEntityFilteredHopper extends TileEntityVisibleInventory impleme
                         if (cart.hasCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)) {
                             IItemHandler items = cart.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
                             int itemsStored;
-                            if (InvUtils.addItemStackToInv(items, ejectStack))
-                                itemsStored = ejectStackSize;
+                            if (InvUtils.addItemStackToInv(items, ejectStack) || ejectStack.stackSize != ejectStackSize)
+                                itemsStored = ejectStackSize - ejectStack.stackSize;
                             else
                                 itemsStored = ejectStackSize - ejectStack.stackSize;
                             if (itemsStored > 0) {

--- a/src/main/java/betterwithmods/event/BucketEvent.java
+++ b/src/main/java/betterwithmods/event/BucketEvent.java
@@ -145,7 +145,7 @@ public class BucketEvent {
             return;
 
         ItemStack toCheck = evt.getEntityPlayer().getHeldItem(evt.getHand());
-        if (toCheck == null || toCheck.getItem() == Items.WATER_BUCKET || !isNonVanillaBucket(toCheck))
+        if (toCheck == null || !(toCheck.getItem() == Items.WATER_BUCKET || isNonVanillaBucket(toCheck)))
             return;
 
         FluidStack fluid = FluidUtil.getFluidContained(toCheck);
@@ -163,7 +163,7 @@ public class BucketEvent {
             state = evt.getWorld().getBlockState(pos);
             if (evt.getWorld().provider.getDimensionType() == DimensionType.OVERWORLD) {
                 if (!block.onBlockActivated(evt.getWorld(), evt.getPos(), state, evt.getEntityPlayer(), evt.getHand(), toCheck, evt.getFace(), 0.5F, 0.5F, 0.5F)) {
-                    if (state.getBlock().isAir(state, evt.getWorld(), pos) || state.getBlock().isReplaceable(evt.getWorld(), pos)) {
+                    if (state.getBlock().isAir(state, evt.getWorld(), pos) || state.getBlock().isReplaceable(evt.getWorld(), pos) || !state.getMaterial().isSolid()) {
                         Item item = toCheck.getItem();
                         if (item.getItemUseAction(toCheck) == EnumAction.NONE) {
                             if (isWater(state)) {
@@ -172,6 +172,7 @@ public class BucketEvent {
                                 }
                             }
                             else {
+                                state.getBlock().dropBlockAsItem(evt.getWorld(), pos, state, 0);
                                 placeContainerFluid(evt, pos, toCheck);
                             }
                         }

--- a/src/main/java/betterwithmods/util/InvUtils.java
+++ b/src/main/java/betterwithmods/util/InvUtils.java
@@ -194,10 +194,15 @@ public class InvUtils {
     }
 
     private static boolean insertingStacks(IItemHandler inv, ItemStack stack, int minSlot, int maxSlot, boolean simulate) {
+        ItemStack leftovers = stack.copy();
         for (int slot = minSlot; slot < maxSlot; slot++) {
-            if (inv.insertItem(slot, stack, simulate) == null)
+            leftovers = inv.insertItem(slot, leftovers, simulate);
+            if (leftovers == null) {
+                stack.stackSize = 0;
                 return true;
+            }
         }
+        stack.stackSize = leftovers.stackSize;
         return false;
     }
 


### PR DESCRIPTION
- First to make the dev env runnable, I changed the ImmersiveEngineering to non-deobf (mapping have changed since that version came out and it doesn't like that)
- The changes in EventBucket change wat appears to be a logic error (L148) and add the `material.isSolid` instead of just relaying on `isReplacable', since that is not what the vanilla bucket or water flow actually use.
- The other changes are all to fix the dupe bug with the not-fully-inserted-stack not being taken out of the  internal inventory.